### PR TITLE
fixup duplicate classes being included inside of the jar files published

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2018-2019 Tomasz Linkowski.
+ * Copyright 2018-2021 Tomasz Linkowski.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -146,5 +146,9 @@ subprojects {
      * 4) TEMP dir (can be set using System properties through "java.io.tmpdir")
      */
     jvmArgsAppend = listOf("-Djmh.separateClasspathJAR=true") // https://bugs.openjdk.java.net/browse/CODETOOLS-7902106
+  }
+
+  tasks.withType<Jar> {
+      duplicatesStrategy = DuplicatesStrategy.EXCLUDE
   }
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2018-2019 Tomasz Linkowski.
+ * Copyright 2018-2021 Tomasz Linkowski.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/subprojects/api/pl.tlinkowski.unij.api/pl.tlinkowski.unij.api.gradle.kts
+++ b/subprojects/api/pl.tlinkowski.unij.api/pl.tlinkowski.unij.api.gradle.kts
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2018-2019 Tomasz Linkowski.
+ * Copyright 2018-2021 Tomasz Linkowski.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/subprojects/api/pl.tlinkowski.unij.api/src/jmh/java/pl/tlinkowski/unij/api/UniListsBenchmark.java
+++ b/subprojects/api/pl.tlinkowski.unij.api/src/jmh/java/pl/tlinkowski/unij/api/UniListsBenchmark.java
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2018-2019 Tomasz Linkowski.
+ * Copyright 2018-2021 Tomasz Linkowski.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package pl.tlinkowski.unij.api;
 
 import java.util.List;

--- a/subprojects/api/pl.tlinkowski.unij.api/src/main/java/module-info.java
+++ b/subprojects/api/pl.tlinkowski.unij.api/src/main/java/module-info.java
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2018-2019 Tomasz Linkowski.
+ * Copyright 2018-2021 Tomasz Linkowski.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 import pl.tlinkowski.unij.api.*;
 import pl.tlinkowski.unij.service.api.collect.*;
 import pl.tlinkowski.unij.service.api.misc.MiscellaneousApiProvider;

--- a/subprojects/api/pl.tlinkowski.unij.api/src/main/java/pl/tlinkowski/unij/api/UniCollectors.java
+++ b/subprojects/api/pl.tlinkowski.unij.api/src/main/java/pl/tlinkowski/unij/api/UniCollectors.java
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2018-2019 Tomasz Linkowski.
+ * Copyright 2018-2021 Tomasz Linkowski.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/subprojects/api/pl.tlinkowski.unij.api/src/main/java/pl/tlinkowski/unij/api/UniJ.java
+++ b/subprojects/api/pl.tlinkowski.unij.api/src/main/java/pl/tlinkowski/unij/api/UniJ.java
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2018-2019 Tomasz Linkowski.
+ * Copyright 2018-2021 Tomasz Linkowski.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/subprojects/api/pl.tlinkowski.unij.api/src/main/java/pl/tlinkowski/unij/api/UniJException.java
+++ b/subprojects/api/pl.tlinkowski.unij.api/src/main/java/pl/tlinkowski/unij/api/UniJException.java
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2018-2019 Tomasz Linkowski.
+ * Copyright 2018-2021 Tomasz Linkowski.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/subprojects/api/pl.tlinkowski.unij.api/src/main/java/pl/tlinkowski/unij/api/UniJLoader.java
+++ b/subprojects/api/pl.tlinkowski.unij.api/src/main/java/pl/tlinkowski/unij/api/UniJLoader.java
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2018-2019 Tomasz Linkowski.
+ * Copyright 2018-2021 Tomasz Linkowski.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/subprojects/api/pl.tlinkowski.unij.api/src/main/java/pl/tlinkowski/unij/api/UniLists.java
+++ b/subprojects/api/pl.tlinkowski.unij.api/src/main/java/pl/tlinkowski/unij/api/UniLists.java
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2018-2019 Tomasz Linkowski.
+ * Copyright 2018-2021 Tomasz Linkowski.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/subprojects/api/pl.tlinkowski.unij.api/src/main/java/pl/tlinkowski/unij/api/UniMaps.java
+++ b/subprojects/api/pl.tlinkowski.unij.api/src/main/java/pl/tlinkowski/unij/api/UniMaps.java
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2018-2019 Tomasz Linkowski.
+ * Copyright 2018-2021 Tomasz Linkowski.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/subprojects/api/pl.tlinkowski.unij.api/src/main/java/pl/tlinkowski/unij/api/UniSets.java
+++ b/subprojects/api/pl.tlinkowski.unij.api/src/main/java/pl/tlinkowski/unij/api/UniSets.java
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2018-2019 Tomasz Linkowski.
+ * Copyright 2018-2021 Tomasz Linkowski.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/subprojects/api/pl.tlinkowski.unij.api/src/main/java/pl/tlinkowski/unij/api/package-info.java
+++ b/subprojects/api/pl.tlinkowski.unij.api/src/main/java/pl/tlinkowski/unij/api/package-info.java
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2018-2019 Tomasz Linkowski.
+ * Copyright 2018-2021 Tomasz Linkowski.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 /**
  * UniJ API for the end users.
  *

--- a/subprojects/api/pl.tlinkowski.unij.api/src/test/groovy/pl/tlinkowski/unij/api/UniCollectorsSpec.groovy
+++ b/subprojects/api/pl.tlinkowski.unij.api/src/test/groovy/pl/tlinkowski/unij/api/UniCollectorsSpec.groovy
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2018-2019 Tomasz Linkowski.
+ * Copyright 2018-2021 Tomasz Linkowski.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package pl.tlinkowski.unij.api
 
 import spock.lang.Specification

--- a/subprojects/api/pl.tlinkowski.unij.api/src/test/groovy/pl/tlinkowski/unij/api/UniJLoaderSpec.groovy
+++ b/subprojects/api/pl.tlinkowski.unij.api/src/test/groovy/pl/tlinkowski/unij/api/UniJLoaderSpec.groovy
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2018-2019 Tomasz Linkowski.
+ * Copyright 2018-2021 Tomasz Linkowski.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package pl.tlinkowski.unij.api
 
 import spock.lang.Specification

--- a/subprojects/api/pl.tlinkowski.unij.api/src/test/groovy/pl/tlinkowski/unij/api/UniListsSpec.groovy
+++ b/subprojects/api/pl.tlinkowski.unij.api/src/test/groovy/pl/tlinkowski/unij/api/UniListsSpec.groovy
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2018-2019 Tomasz Linkowski.
+ * Copyright 2018-2021 Tomasz Linkowski.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package pl.tlinkowski.unij.api
 
 import spock.lang.Specification

--- a/subprojects/api/pl.tlinkowski.unij.api/src/test/groovy/pl/tlinkowski/unij/api/UniMapsSpec.groovy
+++ b/subprojects/api/pl.tlinkowski.unij.api/src/test/groovy/pl/tlinkowski/unij/api/UniMapsSpec.groovy
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2018-2019 Tomasz Linkowski.
+ * Copyright 2018-2021 Tomasz Linkowski.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package pl.tlinkowski.unij.api
 
 import spock.lang.Specification

--- a/subprojects/api/pl.tlinkowski.unij.api/src/test/groovy/pl/tlinkowski/unij/api/UniSetsSpec.groovy
+++ b/subprojects/api/pl.tlinkowski.unij.api/src/test/groovy/pl/tlinkowski/unij/api/UniSetsSpec.groovy
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2018-2019 Tomasz Linkowski.
+ * Copyright 2018-2021 Tomasz Linkowski.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package pl.tlinkowski.unij.api
 
 import spock.lang.Specification

--- a/subprojects/api/pl.tlinkowski.unij.service.api/pl.tlinkowski.unij.service.api.gradle.kts
+++ b/subprojects/api/pl.tlinkowski.unij.service.api/pl.tlinkowski.unij.service.api.gradle.kts
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2018-2019 Tomasz Linkowski.
+ * Copyright 2018-2021 Tomasz Linkowski.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,5 +15,4 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 modularity.mixedJavaRelease(8)

--- a/subprojects/api/pl.tlinkowski.unij.service.api/src/main/java/module-info.java
+++ b/subprojects/api/pl.tlinkowski.unij.service.api/src/main/java/module-info.java
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2018-2019 Tomasz Linkowski.
+ * Copyright 2018-2021 Tomasz Linkowski.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 import pl.tlinkowski.unij.service.api.UniJService;
 
 /**

--- a/subprojects/api/pl.tlinkowski.unij.service.api/src/main/java/pl/tlinkowski/unij/service/api/UniJService.java
+++ b/subprojects/api/pl.tlinkowski.unij.service.api/src/main/java/pl/tlinkowski/unij/service/api/UniJService.java
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2018-2019 Tomasz Linkowski.
+ * Copyright 2018-2021 Tomasz Linkowski.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/subprojects/api/pl.tlinkowski.unij.service.api/src/main/java/pl/tlinkowski/unij/service/api/collect/UnmodifiableListFactory.java
+++ b/subprojects/api/pl.tlinkowski.unij.service.api/src/main/java/pl/tlinkowski/unij/service/api/collect/UnmodifiableListFactory.java
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2018-2019 Tomasz Linkowski.
+ * Copyright 2018-2021 Tomasz Linkowski.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/subprojects/api/pl.tlinkowski.unij.service.api/src/main/java/pl/tlinkowski/unij/service/api/collect/UnmodifiableMapFactory.java
+++ b/subprojects/api/pl.tlinkowski.unij.service.api/src/main/java/pl/tlinkowski/unij/service/api/collect/UnmodifiableMapFactory.java
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2018-2019 Tomasz Linkowski.
+ * Copyright 2018-2021 Tomasz Linkowski.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/subprojects/api/pl.tlinkowski.unij.service.api/src/main/java/pl/tlinkowski/unij/service/api/collect/UnmodifiableSetFactory.java
+++ b/subprojects/api/pl.tlinkowski.unij.service.api/src/main/java/pl/tlinkowski/unij/service/api/collect/UnmodifiableSetFactory.java
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2018-2019 Tomasz Linkowski.
+ * Copyright 2018-2021 Tomasz Linkowski.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/subprojects/api/pl.tlinkowski.unij.service.api/src/main/java/pl/tlinkowski/unij/service/api/collect/package-info.java
+++ b/subprojects/api/pl.tlinkowski.unij.service.api/src/main/java/pl/tlinkowski/unij/service/api/collect/package-info.java
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2018-2019 Tomasz Linkowski.
+ * Copyright 2018-2021 Tomasz Linkowski.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 /**
  * UniJ {@link java.util.Collection}-factory service interfaces.
  *

--- a/subprojects/api/pl.tlinkowski.unij.service.api/src/main/java/pl/tlinkowski/unij/service/api/misc/MiscellaneousApiProvider.java
+++ b/subprojects/api/pl.tlinkowski.unij.service.api/src/main/java/pl/tlinkowski/unij/service/api/misc/MiscellaneousApiProvider.java
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2018-2019 Tomasz Linkowski.
+ * Copyright 2018-2021 Tomasz Linkowski.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/subprojects/api/pl.tlinkowski.unij.service.api/src/main/java/pl/tlinkowski/unij/service/api/misc/package-info.java
+++ b/subprojects/api/pl.tlinkowski.unij.service.api/src/main/java/pl/tlinkowski/unij/service/api/misc/package-info.java
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2018-2019 Tomasz Linkowski.
+ * Copyright 2018-2021 Tomasz Linkowski.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 /**
  * Miscellaneous UniJ service provider interfaces (e.g. {@link pl.tlinkowski.unij.service.api.misc.MiscellaneousApiProvider}).
  *

--- a/subprojects/api/pl.tlinkowski.unij.service.api/src/main/java/pl/tlinkowski/unij/service/api/package-info.java
+++ b/subprojects/api/pl.tlinkowski.unij.service.api/src/main/java/pl/tlinkowski/unij/service/api/package-info.java
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2018-2019 Tomasz Linkowski.
+ * Copyright 2018-2021 Tomasz Linkowski.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 /**
  * API for UniJ services (e.g. {@link pl.tlinkowski.unij.service.api.UniJService} annotation).
  *

--- a/subprojects/bindings/collect/pl.tlinkowski.unij.service.collect.eclipse/pl.tlinkowski.unij.service.collect.eclipse.gradle.kts
+++ b/subprojects/bindings/collect/pl.tlinkowski.unij.service.collect.eclipse/pl.tlinkowski.unij.service.collect.eclipse.gradle.kts
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2018-2019 Tomasz Linkowski.
+ * Copyright 2018-2021 Tomasz Linkowski.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/subprojects/bindings/collect/pl.tlinkowski.unij.service.collect.eclipse/src/main/java/module-info.java
+++ b/subprojects/bindings/collect/pl.tlinkowski.unij.service.collect.eclipse/src/main/java/module-info.java
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2018-2019 Tomasz Linkowski.
+ * Copyright 2018-2021 Tomasz Linkowski.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 import pl.tlinkowski.unij.service.api.collect.*;
 import pl.tlinkowski.unij.service.collect.eclipse.*;
 

--- a/subprojects/bindings/collect/pl.tlinkowski.unij.service.collect.eclipse/src/main/java/pl/tlinkowski/unij/service/collect/eclipse/EclipseUnmodifiableListFactory.java
+++ b/subprojects/bindings/collect/pl.tlinkowski.unij.service.collect.eclipse/src/main/java/pl/tlinkowski/unij/service/collect/eclipse/EclipseUnmodifiableListFactory.java
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2018-2019 Tomasz Linkowski.
+ * Copyright 2018-2021 Tomasz Linkowski.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/subprojects/bindings/collect/pl.tlinkowski.unij.service.collect.eclipse/src/main/java/pl/tlinkowski/unij/service/collect/eclipse/EclipseUnmodifiableMapFactory.java
+++ b/subprojects/bindings/collect/pl.tlinkowski.unij.service.collect.eclipse/src/main/java/pl/tlinkowski/unij/service/collect/eclipse/EclipseUnmodifiableMapFactory.java
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2018-2019 Tomasz Linkowski.
+ * Copyright 2018-2021 Tomasz Linkowski.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/subprojects/bindings/collect/pl.tlinkowski.unij.service.collect.eclipse/src/main/java/pl/tlinkowski/unij/service/collect/eclipse/EclipseUnmodifiableSetFactory.java
+++ b/subprojects/bindings/collect/pl.tlinkowski.unij.service.collect.eclipse/src/main/java/pl/tlinkowski/unij/service/collect/eclipse/EclipseUnmodifiableSetFactory.java
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2018-2019 Tomasz Linkowski.
+ * Copyright 2018-2021 Tomasz Linkowski.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/subprojects/bindings/collect/pl.tlinkowski.unij.service.collect.eclipse/src/main/java/pl/tlinkowski/unij/service/collect/eclipse/package-info.java
+++ b/subprojects/bindings/collect/pl.tlinkowski.unij.service.collect.eclipse/src/main/java/pl/tlinkowski/unij/service/collect/eclipse/package-info.java
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2018-2019 Tomasz Linkowski.
+ * Copyright 2018-2021 Tomasz Linkowski.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 /**
  * UniJ {@link java.util.Collection}-factory service implementations based on
  * <a href="https://www.eclipse.org/collections/">Eclipse Collections</a>.

--- a/subprojects/bindings/collect/pl.tlinkowski.unij.service.collect.eclipse/src/test/groovy/pl/tlinkowski/unij/service/collect/eclipse/EclipseUnmodifiableListFactorySpec.groovy
+++ b/subprojects/bindings/collect/pl.tlinkowski.unij.service.collect.eclipse/src/test/groovy/pl/tlinkowski/unij/service/collect/eclipse/EclipseUnmodifiableListFactorySpec.groovy
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2018-2019 Tomasz Linkowski.
+ * Copyright 2018-2021 Tomasz Linkowski.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package pl.tlinkowski.unij.service.collect.eclipse
 
 import pl.tlinkowski.unij.test.service.collect.UnmodifiableListFactorySpec

--- a/subprojects/bindings/collect/pl.tlinkowski.unij.service.collect.eclipse/src/test/groovy/pl/tlinkowski/unij/service/collect/eclipse/EclipseUnmodifiableMapFactorySpec.groovy
+++ b/subprojects/bindings/collect/pl.tlinkowski.unij.service.collect.eclipse/src/test/groovy/pl/tlinkowski/unij/service/collect/eclipse/EclipseUnmodifiableMapFactorySpec.groovy
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2018-2019 Tomasz Linkowski.
+ * Copyright 2018-2021 Tomasz Linkowski.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package pl.tlinkowski.unij.service.collect.eclipse
 
 import pl.tlinkowski.unij.test.service.collect.UnmodifiableMapFactorySpec

--- a/subprojects/bindings/collect/pl.tlinkowski.unij.service.collect.eclipse/src/test/groovy/pl/tlinkowski/unij/service/collect/eclipse/EclipseUnmodifiableSetFactorySpec.groovy
+++ b/subprojects/bindings/collect/pl.tlinkowski.unij.service.collect.eclipse/src/test/groovy/pl/tlinkowski/unij/service/collect/eclipse/EclipseUnmodifiableSetFactorySpec.groovy
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2018-2019 Tomasz Linkowski.
+ * Copyright 2018-2021 Tomasz Linkowski.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package pl.tlinkowski.unij.service.collect.eclipse
 
 import pl.tlinkowski.unij.test.service.collect.UnmodifiableSetFactorySpec

--- a/subprojects/bindings/collect/pl.tlinkowski.unij.service.collect.guava/pl.tlinkowski.unij.service.collect.guava.gradle.kts
+++ b/subprojects/bindings/collect/pl.tlinkowski.unij.service.collect.guava/pl.tlinkowski.unij.service.collect.guava.gradle.kts
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2018-2019 Tomasz Linkowski.
+ * Copyright 2018-2021 Tomasz Linkowski.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/subprojects/bindings/collect/pl.tlinkowski.unij.service.collect.guava/src/main/java/module-info.java
+++ b/subprojects/bindings/collect/pl.tlinkowski.unij.service.collect.guava/src/main/java/module-info.java
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2018-2019 Tomasz Linkowski.
+ * Copyright 2018-2021 Tomasz Linkowski.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 import pl.tlinkowski.unij.service.api.collect.*;
 import pl.tlinkowski.unij.service.collect.guava.*;
 

--- a/subprojects/bindings/collect/pl.tlinkowski.unij.service.collect.guava/src/main/java/pl/tlinkowski/unij/service/collect/guava/GuavaUnmodifiableListFactory.java
+++ b/subprojects/bindings/collect/pl.tlinkowski.unij.service.collect.guava/src/main/java/pl/tlinkowski/unij/service/collect/guava/GuavaUnmodifiableListFactory.java
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2018-2019 Tomasz Linkowski.
+ * Copyright 2018-2021 Tomasz Linkowski.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/subprojects/bindings/collect/pl.tlinkowski.unij.service.collect.guava/src/main/java/pl/tlinkowski/unij/service/collect/guava/GuavaUnmodifiableMapFactory.java
+++ b/subprojects/bindings/collect/pl.tlinkowski.unij.service.collect.guava/src/main/java/pl/tlinkowski/unij/service/collect/guava/GuavaUnmodifiableMapFactory.java
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2018-2019 Tomasz Linkowski.
+ * Copyright 2018-2021 Tomasz Linkowski.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/subprojects/bindings/collect/pl.tlinkowski.unij.service.collect.guava/src/main/java/pl/tlinkowski/unij/service/collect/guava/GuavaUnmodifiableSetFactory.java
+++ b/subprojects/bindings/collect/pl.tlinkowski.unij.service.collect.guava/src/main/java/pl/tlinkowski/unij/service/collect/guava/GuavaUnmodifiableSetFactory.java
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2018-2019 Tomasz Linkowski.
+ * Copyright 2018-2021 Tomasz Linkowski.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/subprojects/bindings/collect/pl.tlinkowski.unij.service.collect.guava/src/main/java/pl/tlinkowski/unij/service/collect/guava/package-info.java
+++ b/subprojects/bindings/collect/pl.tlinkowski.unij.service.collect.guava/src/main/java/pl/tlinkowski/unij/service/collect/guava/package-info.java
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2018-2019 Tomasz Linkowski.
+ * Copyright 2018-2021 Tomasz Linkowski.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 /**
  * UniJ {@link java.util.Collection}-factory service implementations based on
  * <a href="https://github.com/google/guava">Guava</a>.

--- a/subprojects/bindings/collect/pl.tlinkowski.unij.service.collect.guava/src/test/groovy/pl/tlinkowski/unij/service/collect/guava/GuavaUnmodifiableListFactorySpec.groovy
+++ b/subprojects/bindings/collect/pl.tlinkowski.unij.service.collect.guava/src/test/groovy/pl/tlinkowski/unij/service/collect/guava/GuavaUnmodifiableListFactorySpec.groovy
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2018-2019 Tomasz Linkowski.
+ * Copyright 2018-2021 Tomasz Linkowski.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package pl.tlinkowski.unij.service.collect.guava
 
 import pl.tlinkowski.unij.test.service.collect.UnmodifiableListFactorySpec

--- a/subprojects/bindings/collect/pl.tlinkowski.unij.service.collect.guava/src/test/groovy/pl/tlinkowski/unij/service/collect/guava/GuavaUnmodifiableMapFactorySpec.groovy
+++ b/subprojects/bindings/collect/pl.tlinkowski.unij.service.collect.guava/src/test/groovy/pl/tlinkowski/unij/service/collect/guava/GuavaUnmodifiableMapFactorySpec.groovy
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2018-2019 Tomasz Linkowski.
+ * Copyright 2018-2021 Tomasz Linkowski.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package pl.tlinkowski.unij.service.collect.guava
 
 import pl.tlinkowski.unij.test.service.collect.UnmodifiableMapFactorySpec

--- a/subprojects/bindings/collect/pl.tlinkowski.unij.service.collect.guava/src/test/groovy/pl/tlinkowski/unij/service/collect/guava/GuavaUnmodifiableSetFactorySpec.groovy
+++ b/subprojects/bindings/collect/pl.tlinkowski.unij.service.collect.guava/src/test/groovy/pl/tlinkowski/unij/service/collect/guava/GuavaUnmodifiableSetFactorySpec.groovy
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2018-2019 Tomasz Linkowski.
+ * Copyright 2018-2021 Tomasz Linkowski.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package pl.tlinkowski.unij.service.collect.guava
 
 import pl.tlinkowski.unij.test.service.collect.UnmodifiableSetFactorySpec

--- a/subprojects/bindings/collect/pl.tlinkowski.unij.service.collect.jdk10/pl.tlinkowski.unij.service.collect.jdk10.gradle.kts
+++ b/subprojects/bindings/collect/pl.tlinkowski.unij.service.collect.jdk10/pl.tlinkowski.unij.service.collect.jdk10.gradle.kts
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2018-2019 Tomasz Linkowski.
+ * Copyright 2018-2021 Tomasz Linkowski.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/subprojects/bindings/collect/pl.tlinkowski.unij.service.collect.jdk10/src/main/java/module-info.java
+++ b/subprojects/bindings/collect/pl.tlinkowski.unij.service.collect.jdk10/src/main/java/module-info.java
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2018-2019 Tomasz Linkowski.
+ * Copyright 2018-2021 Tomasz Linkowski.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 import pl.tlinkowski.unij.service.api.collect.*;
 import pl.tlinkowski.unij.service.collect.jdk10.*;
 

--- a/subprojects/bindings/collect/pl.tlinkowski.unij.service.collect.jdk10/src/main/java/pl/tlinkowski/unij/service/collect/jdk10/Jdk10UnmodifiableListFactory.java
+++ b/subprojects/bindings/collect/pl.tlinkowski.unij.service.collect.jdk10/src/main/java/pl/tlinkowski/unij/service/collect/jdk10/Jdk10UnmodifiableListFactory.java
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2018-2019 Tomasz Linkowski.
+ * Copyright 2018-2021 Tomasz Linkowski.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/subprojects/bindings/collect/pl.tlinkowski.unij.service.collect.jdk10/src/main/java/pl/tlinkowski/unij/service/collect/jdk10/Jdk10UnmodifiableMapFactory.java
+++ b/subprojects/bindings/collect/pl.tlinkowski.unij.service.collect.jdk10/src/main/java/pl/tlinkowski/unij/service/collect/jdk10/Jdk10UnmodifiableMapFactory.java
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2018-2019 Tomasz Linkowski.
+ * Copyright 2018-2021 Tomasz Linkowski.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/subprojects/bindings/collect/pl.tlinkowski.unij.service.collect.jdk10/src/main/java/pl/tlinkowski/unij/service/collect/jdk10/Jdk10UnmodifiableSetFactory.java
+++ b/subprojects/bindings/collect/pl.tlinkowski.unij.service.collect.jdk10/src/main/java/pl/tlinkowski/unij/service/collect/jdk10/Jdk10UnmodifiableSetFactory.java
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2018-2019 Tomasz Linkowski.
+ * Copyright 2018-2021 Tomasz Linkowski.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/subprojects/bindings/collect/pl.tlinkowski.unij.service.collect.jdk10/src/main/java/pl/tlinkowski/unij/service/collect/jdk10/package-info.java
+++ b/subprojects/bindings/collect/pl.tlinkowski.unij.service.collect.jdk10/src/main/java/pl/tlinkowski/unij/service/collect/jdk10/package-info.java
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2018-2019 Tomasz Linkowski.
+ * Copyright 2018-2021 Tomasz Linkowski.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 /**
  * UniJ {@link java.util.Collection}-factory service implementations based on JDK 10.
  *

--- a/subprojects/bindings/collect/pl.tlinkowski.unij.service.collect.jdk10/src/test/groovy/pl/tlinkowski/unij/service/collect/jdk10/Jdk10UnmodifiableListFactorySpec.groovy
+++ b/subprojects/bindings/collect/pl.tlinkowski.unij.service.collect.jdk10/src/test/groovy/pl/tlinkowski/unij/service/collect/jdk10/Jdk10UnmodifiableListFactorySpec.groovy
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2018-2019 Tomasz Linkowski.
+ * Copyright 2018-2021 Tomasz Linkowski.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/subprojects/bindings/collect/pl.tlinkowski.unij.service.collect.jdk10/src/test/groovy/pl/tlinkowski/unij/service/collect/jdk10/Jdk10UnmodifiableMapFactorySpec.groovy
+++ b/subprojects/bindings/collect/pl.tlinkowski.unij.service.collect.jdk10/src/test/groovy/pl/tlinkowski/unij/service/collect/jdk10/Jdk10UnmodifiableMapFactorySpec.groovy
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2018-2019 Tomasz Linkowski.
+ * Copyright 2018-2021 Tomasz Linkowski.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/subprojects/bindings/collect/pl.tlinkowski.unij.service.collect.jdk10/src/test/groovy/pl/tlinkowski/unij/service/collect/jdk10/Jdk10UnmodifiableSetFactorySpec.groovy
+++ b/subprojects/bindings/collect/pl.tlinkowski.unij.service.collect.jdk10/src/test/groovy/pl/tlinkowski/unij/service/collect/jdk10/Jdk10UnmodifiableSetFactorySpec.groovy
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2018-2019 Tomasz Linkowski.
+ * Copyright 2018-2021 Tomasz Linkowski.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/subprojects/bindings/collect/pl.tlinkowski.unij.service.collect.jdk8/pl.tlinkowski.unij.service.collect.jdk8.gradle.kts
+++ b/subprojects/bindings/collect/pl.tlinkowski.unij.service.collect.jdk8/pl.tlinkowski.unij.service.collect.jdk8.gradle.kts
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2018-2019 Tomasz Linkowski.
+ * Copyright 2018-2021 Tomasz Linkowski.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/subprojects/bindings/collect/pl.tlinkowski.unij.service.collect.jdk8/src/main/java/module-info.java
+++ b/subprojects/bindings/collect/pl.tlinkowski.unij.service.collect.jdk8/src/main/java/module-info.java
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2018-2019 Tomasz Linkowski.
+ * Copyright 2018-2021 Tomasz Linkowski.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 import pl.tlinkowski.unij.service.api.collect.*;
 import pl.tlinkowski.unij.service.collect.jdk8.*;
 

--- a/subprojects/bindings/collect/pl.tlinkowski.unij.service.collect.jdk8/src/main/java/pl/tlinkowski/unij/service/collect/jdk8/Jdk8UnmodifiableListFactory.java
+++ b/subprojects/bindings/collect/pl.tlinkowski.unij.service.collect.jdk8/src/main/java/pl/tlinkowski/unij/service/collect/jdk8/Jdk8UnmodifiableListFactory.java
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2018-2019 Tomasz Linkowski.
+ * Copyright 2018-2021 Tomasz Linkowski.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/subprojects/bindings/collect/pl.tlinkowski.unij.service.collect.jdk8/src/main/java/pl/tlinkowski/unij/service/collect/jdk8/Jdk8UnmodifiableMapFactory.java
+++ b/subprojects/bindings/collect/pl.tlinkowski.unij.service.collect.jdk8/src/main/java/pl/tlinkowski/unij/service/collect/jdk8/Jdk8UnmodifiableMapFactory.java
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2018-2019 Tomasz Linkowski.
+ * Copyright 2018-2021 Tomasz Linkowski.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/subprojects/bindings/collect/pl.tlinkowski.unij.service.collect.jdk8/src/main/java/pl/tlinkowski/unij/service/collect/jdk8/Jdk8UnmodifiableSetFactory.java
+++ b/subprojects/bindings/collect/pl.tlinkowski.unij.service.collect.jdk8/src/main/java/pl/tlinkowski/unij/service/collect/jdk8/Jdk8UnmodifiableSetFactory.java
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2018-2019 Tomasz Linkowski.
+ * Copyright 2018-2021 Tomasz Linkowski.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/subprojects/bindings/collect/pl.tlinkowski.unij.service.collect.jdk8/src/main/java/pl/tlinkowski/unij/service/collect/jdk8/package-info.java
+++ b/subprojects/bindings/collect/pl.tlinkowski.unij.service.collect.jdk8/src/main/java/pl/tlinkowski/unij/service/collect/jdk8/package-info.java
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2018-2019 Tomasz Linkowski.
+ * Copyright 2018-2021 Tomasz Linkowski.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 /**
  * UniJ {@link java.util.Collection}-factory service implementations based on JDK 8.
  *

--- a/subprojects/bindings/collect/pl.tlinkowski.unij.service.collect.jdk8/src/test/groovy/pl/tlinkowski/unij/service/collect/jdk8/Jdk8UnmodifiableListFactorySpec.groovy
+++ b/subprojects/bindings/collect/pl.tlinkowski.unij.service.collect.jdk8/src/test/groovy/pl/tlinkowski/unij/service/collect/jdk8/Jdk8UnmodifiableListFactorySpec.groovy
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2018-2019 Tomasz Linkowski.
+ * Copyright 2018-2021 Tomasz Linkowski.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package pl.tlinkowski.unij.service.collect.jdk8
 
 import pl.tlinkowski.unij.test.service.collect.UnmodifiableListFactorySpec

--- a/subprojects/bindings/collect/pl.tlinkowski.unij.service.collect.jdk8/src/test/groovy/pl/tlinkowski/unij/service/collect/jdk8/Jdk8UnmodifiableMapFactorySpec.groovy
+++ b/subprojects/bindings/collect/pl.tlinkowski.unij.service.collect.jdk8/src/test/groovy/pl/tlinkowski/unij/service/collect/jdk8/Jdk8UnmodifiableMapFactorySpec.groovy
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2018-2019 Tomasz Linkowski.
+ * Copyright 2018-2021 Tomasz Linkowski.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package pl.tlinkowski.unij.service.collect.jdk8
 
 import pl.tlinkowski.unij.test.service.collect.UnmodifiableMapFactorySpec

--- a/subprojects/bindings/collect/pl.tlinkowski.unij.service.collect.jdk8/src/test/groovy/pl/tlinkowski/unij/service/collect/jdk8/Jdk8UnmodifiableSetFactorySpec.groovy
+++ b/subprojects/bindings/collect/pl.tlinkowski.unij.service.collect.jdk8/src/test/groovy/pl/tlinkowski/unij/service/collect/jdk8/Jdk8UnmodifiableSetFactorySpec.groovy
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2018-2019 Tomasz Linkowski.
+ * Copyright 2018-2021 Tomasz Linkowski.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package pl.tlinkowski.unij.service.collect.jdk8
 
 import pl.tlinkowski.unij.test.service.collect.UnmodifiableSetFactorySpec

--- a/subprojects/bindings/misc/pl.tlinkowski.unij.service.misc.jdk11/pl.tlinkowski.unij.service.misc.jdk11.gradle.kts
+++ b/subprojects/bindings/misc/pl.tlinkowski.unij.service.misc.jdk11/pl.tlinkowski.unij.service.misc.jdk11.gradle.kts
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2018-2019 Tomasz Linkowski.
+ * Copyright 2018-2021 Tomasz Linkowski.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/subprojects/bindings/misc/pl.tlinkowski.unij.service.misc.jdk11/src/main/java/module-info.java
+++ b/subprojects/bindings/misc/pl.tlinkowski.unij.service.misc.jdk11/src/main/java/module-info.java
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2018-2019 Tomasz Linkowski.
+ * Copyright 2018-2021 Tomasz Linkowski.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 import pl.tlinkowski.unij.service.api.misc.MiscellaneousApiProvider;
 import pl.tlinkowski.unij.service.misc.jdk11.Jdk11MiscellaneousApiProvider;
 

--- a/subprojects/bindings/misc/pl.tlinkowski.unij.service.misc.jdk11/src/main/java/pl/tlinkowski/unij/service/misc/jdk11/Jdk11MiscellaneousApiProvider.java
+++ b/subprojects/bindings/misc/pl.tlinkowski.unij.service.misc.jdk11/src/main/java/pl/tlinkowski/unij/service/misc/jdk11/Jdk11MiscellaneousApiProvider.java
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2018-2019 Tomasz Linkowski.
+ * Copyright 2018-2021 Tomasz Linkowski.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/subprojects/bindings/misc/pl.tlinkowski.unij.service.misc.jdk11/src/main/java/pl/tlinkowski/unij/service/misc/jdk11/package-info.java
+++ b/subprojects/bindings/misc/pl.tlinkowski.unij.service.misc.jdk11/src/main/java/pl/tlinkowski/unij/service/misc/jdk11/package-info.java
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2018-2019 Tomasz Linkowski.
+ * Copyright 2018-2021 Tomasz Linkowski.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 /**
  * UniJ miscellaneous service implementations based on JDK 11.
  *

--- a/subprojects/bindings/misc/pl.tlinkowski.unij.service.misc.jdk11/src/test/groovy/pl/tlinkowski/unij/service/misc/jdk11/Jdk11MiscellaneousApiProviderSpec.groovy
+++ b/subprojects/bindings/misc/pl.tlinkowski.unij.service.misc.jdk11/src/test/groovy/pl/tlinkowski/unij/service/misc/jdk11/Jdk11MiscellaneousApiProviderSpec.groovy
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2018-2019 Tomasz Linkowski.
+ * Copyright 2018-2021 Tomasz Linkowski.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package pl.tlinkowski.unij.service.misc.jdk11
 
 import pl.tlinkowski.unij.test.service.misc.MiscellaneousApiProviderSpec

--- a/subprojects/bindings/misc/pl.tlinkowski.unij.service.misc.jdk8/pl.tlinkowski.unij.service.misc.jdk8.gradle.kts
+++ b/subprojects/bindings/misc/pl.tlinkowski.unij.service.misc.jdk8/pl.tlinkowski.unij.service.misc.jdk8.gradle.kts
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2018-2019 Tomasz Linkowski.
+ * Copyright 2018-2021 Tomasz Linkowski.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/subprojects/bindings/misc/pl.tlinkowski.unij.service.misc.jdk8/src/main/java/module-info.java
+++ b/subprojects/bindings/misc/pl.tlinkowski.unij.service.misc.jdk8/src/main/java/module-info.java
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2018-2019 Tomasz Linkowski.
+ * Copyright 2018-2021 Tomasz Linkowski.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 import pl.tlinkowski.unij.service.api.misc.MiscellaneousApiProvider;
 import pl.tlinkowski.unij.service.misc.jdk8.Jdk8MiscellaneousApiProvider;
 

--- a/subprojects/bindings/misc/pl.tlinkowski.unij.service.misc.jdk8/src/main/java/pl/tlinkowski/unij/service/misc/jdk8/Jdk8MiscellaneousApiProvider.java
+++ b/subprojects/bindings/misc/pl.tlinkowski.unij.service.misc.jdk8/src/main/java/pl/tlinkowski/unij/service/misc/jdk8/Jdk8MiscellaneousApiProvider.java
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2018-2019 Tomasz Linkowski.
+ * Copyright 2018-2021 Tomasz Linkowski.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/subprojects/bindings/misc/pl.tlinkowski.unij.service.misc.jdk8/src/main/java/pl/tlinkowski/unij/service/misc/jdk8/package-info.java
+++ b/subprojects/bindings/misc/pl.tlinkowski.unij.service.misc.jdk8/src/main/java/pl/tlinkowski/unij/service/misc/jdk8/package-info.java
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2018-2019 Tomasz Linkowski.
+ * Copyright 2018-2021 Tomasz Linkowski.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 /**
  * UniJ miscellaneous service implementations based on JDK 8.
  *

--- a/subprojects/bindings/misc/pl.tlinkowski.unij.service.misc.jdk8/src/test/groovy/pl/tlinkowski/unij/service/misc/jdk8/Jdk8MiscellaneousApiProviderSpec.groovy
+++ b/subprojects/bindings/misc/pl.tlinkowski.unij.service.misc.jdk8/src/test/groovy/pl/tlinkowski/unij/service/misc/jdk8/Jdk8MiscellaneousApiProviderSpec.groovy
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2018-2019 Tomasz Linkowski.
+ * Copyright 2018-2021 Tomasz Linkowski.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package pl.tlinkowski.unij.service.misc.jdk8
 
 import pl.tlinkowski.unij.test.service.misc.MiscellaneousApiProviderSpec

--- a/subprojects/bundles/pl.tlinkowski.unij.bundle.eclipse_jdk8/pl.tlinkowski.unij.bundle.eclipse_jdk8.gradle.kts
+++ b/subprojects/bundles/pl.tlinkowski.unij.bundle.eclipse_jdk8/pl.tlinkowski.unij.bundle.eclipse_jdk8.gradle.kts
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2018-2019 Tomasz Linkowski.
+ * Copyright 2018-2021 Tomasz Linkowski.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/subprojects/bundles/pl.tlinkowski.unij.bundle.eclipse_jdk8/src/main/java/module-info.java
+++ b/subprojects/bundles/pl.tlinkowski.unij.bundle.eclipse_jdk8/src/main/java/module-info.java
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2018-2019 Tomasz Linkowski.
+ * Copyright 2018-2021 Tomasz Linkowski.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 /**
  * A bundle of bindings for UniJ:
  * <ul>

--- a/subprojects/bundles/pl.tlinkowski.unij.bundle.eclipse_jdk8/src/test/groovy/pl/tlinkowski/unij/bundle/eclipse_jdk8/EclipseJdk8BundleTest.groovy
+++ b/subprojects/bundles/pl.tlinkowski.unij.bundle.eclipse_jdk8/src/test/groovy/pl/tlinkowski/unij/bundle/eclipse_jdk8/EclipseJdk8BundleTest.groovy
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2018-2019 Tomasz Linkowski.
+ * Copyright 2018-2021 Tomasz Linkowski.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package pl.tlinkowski.unij.bundle.eclipse_jdk8
 
 import pl.tlinkowski.unij.test.bundle.UniJBundleTest

--- a/subprojects/bundles/pl.tlinkowski.unij.bundle.guava_jdk8/pl.tlinkowski.unij.bundle.guava_jdk8.gradle.kts
+++ b/subprojects/bundles/pl.tlinkowski.unij.bundle.guava_jdk8/pl.tlinkowski.unij.bundle.guava_jdk8.gradle.kts
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2018-2019 Tomasz Linkowski.
+ * Copyright 2018-2021 Tomasz Linkowski.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/subprojects/bundles/pl.tlinkowski.unij.bundle.guava_jdk8/src/main/java/module-info.java
+++ b/subprojects/bundles/pl.tlinkowski.unij.bundle.guava_jdk8/src/main/java/module-info.java
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2018-2019 Tomasz Linkowski.
+ * Copyright 2018-2021 Tomasz Linkowski.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 /**
  * A bundle of bindings for UniJ:
  * <ul>

--- a/subprojects/bundles/pl.tlinkowski.unij.bundle.guava_jdk8/src/test/groovy/pl/tlinkowski/unij/bundle/guava_jdk8/GuavaJdk8BundleTest.groovy
+++ b/subprojects/bundles/pl.tlinkowski.unij.bundle.guava_jdk8/src/test/groovy/pl/tlinkowski/unij/bundle/guava_jdk8/GuavaJdk8BundleTest.groovy
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2018-2019 Tomasz Linkowski.
+ * Copyright 2018-2021 Tomasz Linkowski.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package pl.tlinkowski.unij.bundle.guava_jdk8
 
 import pl.tlinkowski.unij.test.bundle.UniJBundleTest

--- a/subprojects/bundles/pl.tlinkowski.unij.bundle.jdk11/pl.tlinkowski.unij.bundle.jdk11.gradle.kts
+++ b/subprojects/bundles/pl.tlinkowski.unij.bundle.jdk11/pl.tlinkowski.unij.bundle.jdk11.gradle.kts
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2018-2019 Tomasz Linkowski.
+ * Copyright 2018-2021 Tomasz Linkowski.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/subprojects/bundles/pl.tlinkowski.unij.bundle.jdk11/src/main/java/module-info.java
+++ b/subprojects/bundles/pl.tlinkowski.unij.bundle.jdk11/src/main/java/module-info.java
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2018-2019 Tomasz Linkowski.
+ * Copyright 2018-2021 Tomasz Linkowski.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 /**
  * A bundle of bindings for UniJ:
  * <ul>

--- a/subprojects/bundles/pl.tlinkowski.unij.bundle.jdk11/src/test/groovy/pl/tlinkowski/unij/bundle/jdk11/Jdk11BundleTest.groovy
+++ b/subprojects/bundles/pl.tlinkowski.unij.bundle.jdk11/src/test/groovy/pl/tlinkowski/unij/bundle/jdk11/Jdk11BundleTest.groovy
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2018-2019 Tomasz Linkowski.
+ * Copyright 2018-2021 Tomasz Linkowski.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package pl.tlinkowski.unij.bundle.jdk11
 
 import pl.tlinkowski.unij.test.bundle.UniJBundleTest

--- a/subprojects/bundles/pl.tlinkowski.unij.bundle.jdk8/pl.tlinkowski.unij.bundle.jdk8.gradle.kts
+++ b/subprojects/bundles/pl.tlinkowski.unij.bundle.jdk8/pl.tlinkowski.unij.bundle.jdk8.gradle.kts
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2018-2019 Tomasz Linkowski.
+ * Copyright 2018-2021 Tomasz Linkowski.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/subprojects/bundles/pl.tlinkowski.unij.bundle.jdk8/src/main/java/module-info.java
+++ b/subprojects/bundles/pl.tlinkowski.unij.bundle.jdk8/src/main/java/module-info.java
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2018-2019 Tomasz Linkowski.
+ * Copyright 2018-2021 Tomasz Linkowski.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 /**
  * A bundle of bindings for UniJ:
  * <ul>

--- a/subprojects/bundles/pl.tlinkowski.unij.bundle.jdk8/src/test/groovy/pl/tlinkowski/unij/bundle/jdk8/Jdk8BundleTest.groovy
+++ b/subprojects/bundles/pl.tlinkowski.unij.bundle.jdk8/src/test/groovy/pl/tlinkowski/unij/bundle/jdk8/Jdk8BundleTest.groovy
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2018-2019 Tomasz Linkowski.
+ * Copyright 2018-2021 Tomasz Linkowski.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package pl.tlinkowski.unij.bundle.jdk8
 
 import pl.tlinkowski.unij.test.bundle.UniJBundleTest

--- a/subprojects/pl.tlinkowski.unij.test/pl.tlinkowski.unij.test.gradle.kts
+++ b/subprojects/pl.tlinkowski.unij.test/pl.tlinkowski.unij.test.gradle.kts
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2018-2019 Tomasz Linkowski.
+ * Copyright 2018-2021 Tomasz Linkowski.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/subprojects/pl.tlinkowski.unij.test/src/main/groovy/pl/tlinkowski/unij/test/bundle/UniJBundleTest.groovy
+++ b/subprojects/pl.tlinkowski.unij.test/src/main/groovy/pl/tlinkowski/unij/test/bundle/UniJBundleTest.groovy
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2018-2019 Tomasz Linkowski.
+ * Copyright 2018-2021 Tomasz Linkowski.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package pl.tlinkowski.unij.test.bundle
 
 import spock.lang.Specification

--- a/subprojects/pl.tlinkowski.unij.test/src/main/groovy/pl/tlinkowski/unij/test/bundle/package-info.java
+++ b/subprojects/pl.tlinkowski.unij.test/src/main/groovy/pl/tlinkowski/unij/test/bundle/package-info.java
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2018-2019 Tomasz Linkowski.
+ * Copyright 2018-2021 Tomasz Linkowski.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 /**
  * @author Tomasz Linkowski
  */

--- a/subprojects/pl.tlinkowski.unij.test/src/main/groovy/pl/tlinkowski/unij/test/service/collect/UnmodifiableCollectionSpecHelper.groovy
+++ b/subprojects/pl.tlinkowski.unij.test/src/main/groovy/pl/tlinkowski/unij/test/service/collect/UnmodifiableCollectionSpecHelper.groovy
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2018-2019 Tomasz Linkowski.
+ * Copyright 2018-2021 Tomasz Linkowski.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package pl.tlinkowski.unij.test.service.collect
 
 import groovy.transform.PackageScope

--- a/subprojects/pl.tlinkowski.unij.test/src/main/groovy/pl/tlinkowski/unij/test/service/collect/UnmodifiableListFactorySpec.groovy
+++ b/subprojects/pl.tlinkowski.unij.test/src/main/groovy/pl/tlinkowski/unij/test/service/collect/UnmodifiableListFactorySpec.groovy
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2018-2019 Tomasz Linkowski.
+ * Copyright 2018-2021 Tomasz Linkowski.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package pl.tlinkowski.unij.test.service.collect
 
 import static pl.tlinkowski.unij.test.service.collect.UnmodifiableCollectionSpecHelper.*

--- a/subprojects/pl.tlinkowski.unij.test/src/main/groovy/pl/tlinkowski/unij/test/service/collect/UnmodifiableMapFactorySpec.groovy
+++ b/subprojects/pl.tlinkowski.unij.test/src/main/groovy/pl/tlinkowski/unij/test/service/collect/UnmodifiableMapFactorySpec.groovy
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2018-2019 Tomasz Linkowski.
+ * Copyright 2018-2021 Tomasz Linkowski.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package pl.tlinkowski.unij.test.service.collect
 
 import static pl.tlinkowski.unij.test.service.collect.UnmodifiableMapSpecHelper.*

--- a/subprojects/pl.tlinkowski.unij.test/src/main/groovy/pl/tlinkowski/unij/test/service/collect/UnmodifiableMapSpecHelper.groovy
+++ b/subprojects/pl.tlinkowski.unij.test/src/main/groovy/pl/tlinkowski/unij/test/service/collect/UnmodifiableMapSpecHelper.groovy
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2018-2019 Tomasz Linkowski.
+ * Copyright 2018-2021 Tomasz Linkowski.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package pl.tlinkowski.unij.test.service.collect
 
 import groovy.transform.PackageScope

--- a/subprojects/pl.tlinkowski.unij.test/src/main/groovy/pl/tlinkowski/unij/test/service/collect/UnmodifiableSetFactorySpec.groovy
+++ b/subprojects/pl.tlinkowski.unij.test/src/main/groovy/pl/tlinkowski/unij/test/service/collect/UnmodifiableSetFactorySpec.groovy
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2018-2019 Tomasz Linkowski.
+ * Copyright 2018-2021 Tomasz Linkowski.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package pl.tlinkowski.unij.test.service.collect
 
 import static pl.tlinkowski.unij.test.service.collect.UnmodifiableCollectionSpecHelper.*

--- a/subprojects/pl.tlinkowski.unij.test/src/main/groovy/pl/tlinkowski/unij/test/service/collect/package-info.java
+++ b/subprojects/pl.tlinkowski.unij.test/src/main/groovy/pl/tlinkowski/unij/test/service/collect/package-info.java
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2018-2019 Tomasz Linkowski.
+ * Copyright 2018-2021 Tomasz Linkowski.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 /**
  * Test classes (specifications) for UniJ {@link java.util.Collection}-factory services.
  *

--- a/subprojects/pl.tlinkowski.unij.test/src/main/groovy/pl/tlinkowski/unij/test/service/misc/MiscellaneousApiProviderSpec.groovy
+++ b/subprojects/pl.tlinkowski.unij.test/src/main/groovy/pl/tlinkowski/unij/test/service/misc/MiscellaneousApiProviderSpec.groovy
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2018-2019 Tomasz Linkowski.
+ * Copyright 2018-2021 Tomasz Linkowski.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package pl.tlinkowski.unij.test.service.misc
 
 import spock.lang.Shared

--- a/subprojects/samples/enduser/pl.tlinkowski.unij.sample.enduser.jdk11/pl.tlinkowski.unij.sample.enduser.jdk11.gradle.kts
+++ b/subprojects/samples/enduser/pl.tlinkowski.unij.sample.enduser.jdk11/pl.tlinkowski.unij.sample.enduser.jdk11.gradle.kts
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2018-2019 Tomasz Linkowski.
+ * Copyright 2018-2021 Tomasz Linkowski.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 plugins {
   application
 }

--- a/subprojects/samples/enduser/pl.tlinkowski.unij.sample.enduser.jdk11/src/main/java/module-info.java
+++ b/subprojects/samples/enduser/pl.tlinkowski.unij.sample.enduser.jdk11/src/main/java/module-info.java
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2018-2019 Tomasz Linkowski.
+ * Copyright 2018-2021 Tomasz Linkowski.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 /**
  * @author Tomasz Linkowski
  */

--- a/subprojects/samples/enduser/pl.tlinkowski.unij.sample.enduser.jdk11/src/main/java/pl/tlinkowski/unij/sample/enduser/jdk11/EndUsage.java
+++ b/subprojects/samples/enduser/pl.tlinkowski.unij.sample.enduser.jdk11/src/main/java/pl/tlinkowski/unij/sample/enduser/jdk11/EndUsage.java
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2018-2019 Tomasz Linkowski.
+ * Copyright 2018-2021 Tomasz Linkowski.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/subprojects/samples/enduser/pl.tlinkowski.unij.sample.enduser.jdk11/src/main/java/pl/tlinkowski/unij/sample/enduser/jdk11/package-info.java
+++ b/subprojects/samples/enduser/pl.tlinkowski.unij.sample.enduser.jdk11/src/main/java/pl/tlinkowski/unij/sample/enduser/jdk11/package-info.java
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2018-2019 Tomasz Linkowski.
+ * Copyright 2018-2021 Tomasz Linkowski.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 /**
  * @author Tomasz Linkowski
  */

--- a/subprojects/samples/enduser/pl.tlinkowski.unij.sample.enduser.jdk11/src/test/groovy/pl/tlinkowski/unij/sample/enduser/jdk11/EndUsageSpec.groovy
+++ b/subprojects/samples/enduser/pl.tlinkowski.unij.sample.enduser.jdk11/src/test/groovy/pl/tlinkowski/unij/sample/enduser/jdk11/EndUsageSpec.groovy
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2018-2019 Tomasz Linkowski.
+ * Copyright 2018-2021 Tomasz Linkowski.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package pl.tlinkowski.unij.sample.enduser.jdk11
 
 import spock.lang.Specification

--- a/subprojects/samples/enduser/pl.tlinkowski.unij.sample.enduser.jdk8/pl.tlinkowski.unij.sample.enduser.jdk8.gradle.kts
+++ b/subprojects/samples/enduser/pl.tlinkowski.unij.sample.enduser.jdk8/pl.tlinkowski.unij.sample.enduser.jdk8.gradle.kts
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2018-2019 Tomasz Linkowski.
+ * Copyright 2018-2021 Tomasz Linkowski.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 plugins {
   application
 }

--- a/subprojects/samples/enduser/pl.tlinkowski.unij.sample.enduser.jdk8/src/main/java/module-info.java
+++ b/subprojects/samples/enduser/pl.tlinkowski.unij.sample.enduser.jdk8/src/main/java/module-info.java
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2018-2019 Tomasz Linkowski.
+ * Copyright 2018-2021 Tomasz Linkowski.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 /**
  * @author Tomasz Linkowski
  */

--- a/subprojects/samples/enduser/pl.tlinkowski.unij.sample.enduser.jdk8/src/main/java/pl/tlinkowski/unij/sample/enduser/jdk8/EndUsage.java
+++ b/subprojects/samples/enduser/pl.tlinkowski.unij.sample.enduser.jdk8/src/main/java/pl/tlinkowski/unij/sample/enduser/jdk8/EndUsage.java
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2018-2019 Tomasz Linkowski.
+ * Copyright 2018-2021 Tomasz Linkowski.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/subprojects/samples/enduser/pl.tlinkowski.unij.sample.enduser.jdk8/src/main/java/pl/tlinkowski/unij/sample/enduser/jdk8/package-info.java
+++ b/subprojects/samples/enduser/pl.tlinkowski.unij.sample.enduser.jdk8/src/main/java/pl/tlinkowski/unij/sample/enduser/jdk8/package-info.java
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2018-2019 Tomasz Linkowski.
+ * Copyright 2018-2021 Tomasz Linkowski.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 /**
  * @author Tomasz Linkowski
  */

--- a/subprojects/samples/enduser/pl.tlinkowski.unij.sample.enduser.jdk8/src/test/groovy/pl/tlinkowski/unij/sample/enduser/jdk8/EndUsageSpec.groovy
+++ b/subprojects/samples/enduser/pl.tlinkowski.unij.sample.enduser.jdk8/src/test/groovy/pl/tlinkowski/unij/sample/enduser/jdk8/EndUsageSpec.groovy
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2018-2019 Tomasz Linkowski.
+ * Copyright 2018-2021 Tomasz Linkowski.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package pl.tlinkowski.unij.sample.enduser.jdk8
 
 import spock.lang.Specification

--- a/subprojects/samples/lib/pl.tlinkowski.unij.sample.lib.usage.eclipse/pl.tlinkowski.unij.sample.lib.usage.eclipse.gradle.kts
+++ b/subprojects/samples/lib/pl.tlinkowski.unij.sample.lib.usage.eclipse/pl.tlinkowski.unij.sample.lib.usage.eclipse.gradle.kts
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2018-2019 Tomasz Linkowski.
+ * Copyright 2018-2021 Tomasz Linkowski.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 plugins {
   application
 }

--- a/subprojects/samples/lib/pl.tlinkowski.unij.sample.lib.usage.eclipse/src/main/java/module-info.java
+++ b/subprojects/samples/lib/pl.tlinkowski.unij.sample.lib.usage.eclipse/src/main/java/module-info.java
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2018-2019 Tomasz Linkowski.
+ * Copyright 2018-2021 Tomasz Linkowski.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 /**
  * @author Tomasz Linkowski
  */

--- a/subprojects/samples/lib/pl.tlinkowski.unij.sample.lib.usage.eclipse/src/main/java/pl/tlinkowski/unij/sample/lib/usage/eclipse/SampleLogicMain.java
+++ b/subprojects/samples/lib/pl.tlinkowski.unij.sample.lib.usage.eclipse/src/main/java/pl/tlinkowski/unij/sample/lib/usage/eclipse/SampleLogicMain.java
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2018-2019 Tomasz Linkowski.
+ * Copyright 2018-2021 Tomasz Linkowski.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/subprojects/samples/lib/pl.tlinkowski.unij.sample.lib.usage.eclipse/src/main/java/pl/tlinkowski/unij/sample/lib/usage/eclipse/package-info.java
+++ b/subprojects/samples/lib/pl.tlinkowski.unij.sample.lib.usage.eclipse/src/main/java/pl/tlinkowski/unij/sample/lib/usage/eclipse/package-info.java
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2018-2019 Tomasz Linkowski.
+ * Copyright 2018-2021 Tomasz Linkowski.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 /**
  * @author Tomasz Linkowski
  */

--- a/subprojects/samples/lib/pl.tlinkowski.unij.sample.lib.usage.eclipse/src/test/groovy/pl/tlinkowski/unij/sample/lib/usage/eclipse/SampleLogicSpec.groovy
+++ b/subprojects/samples/lib/pl.tlinkowski.unij.sample.lib.usage.eclipse/src/test/groovy/pl/tlinkowski/unij/sample/lib/usage/eclipse/SampleLogicSpec.groovy
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2018-2019 Tomasz Linkowski.
+ * Copyright 2018-2021 Tomasz Linkowski.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package pl.tlinkowski.unij.sample.lib.usage.eclipse
 
 import spock.lang.Specification

--- a/subprojects/samples/lib/pl.tlinkowski.unij.sample.lib.usage.guava/pl.tlinkowski.unij.sample.lib.usage.guava.gradle.kts
+++ b/subprojects/samples/lib/pl.tlinkowski.unij.sample.lib.usage.guava/pl.tlinkowski.unij.sample.lib.usage.guava.gradle.kts
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2018-2019 Tomasz Linkowski.
+ * Copyright 2018-2021 Tomasz Linkowski.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 plugins {
   application
 }

--- a/subprojects/samples/lib/pl.tlinkowski.unij.sample.lib.usage.guava/src/main/java/module-info.java
+++ b/subprojects/samples/lib/pl.tlinkowski.unij.sample.lib.usage.guava/src/main/java/module-info.java
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2018-2019 Tomasz Linkowski.
+ * Copyright 2018-2021 Tomasz Linkowski.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 /**
  * @author Tomasz Linkowski
  */

--- a/subprojects/samples/lib/pl.tlinkowski.unij.sample.lib.usage.guava/src/main/java/pl/tlinkowski/unij/sample/lib/usage/guava/SampleLogicMain.java
+++ b/subprojects/samples/lib/pl.tlinkowski.unij.sample.lib.usage.guava/src/main/java/pl/tlinkowski/unij/sample/lib/usage/guava/SampleLogicMain.java
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2018-2019 Tomasz Linkowski.
+ * Copyright 2018-2021 Tomasz Linkowski.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/subprojects/samples/lib/pl.tlinkowski.unij.sample.lib.usage.guava/src/main/java/pl/tlinkowski/unij/sample/lib/usage/guava/package-info.java
+++ b/subprojects/samples/lib/pl.tlinkowski.unij.sample.lib.usage.guava/src/main/java/pl/tlinkowski/unij/sample/lib/usage/guava/package-info.java
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2018-2019 Tomasz Linkowski.
+ * Copyright 2018-2021 Tomasz Linkowski.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 /**
  * @author Tomasz Linkowski
  */

--- a/subprojects/samples/lib/pl.tlinkowski.unij.sample.lib.usage.guava/src/test/groovy/pl/tlinkowski/unij/sample/lib/usage/guava/SampleLogicSpec.groovy
+++ b/subprojects/samples/lib/pl.tlinkowski.unij.sample.lib.usage.guava/src/test/groovy/pl/tlinkowski/unij/sample/lib/usage/guava/SampleLogicSpec.groovy
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2018-2019 Tomasz Linkowski.
+ * Copyright 2018-2021 Tomasz Linkowski.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package pl.tlinkowski.unij.sample.lib.usage.guava
 
 import spock.lang.Specification

--- a/subprojects/samples/lib/pl.tlinkowski.unij.sample.lib.usage.jdk11/pl.tlinkowski.unij.sample.lib.usage.jdk11.gradle.kts
+++ b/subprojects/samples/lib/pl.tlinkowski.unij.sample.lib.usage.jdk11/pl.tlinkowski.unij.sample.lib.usage.jdk11.gradle.kts
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2018-2019 Tomasz Linkowski.
+ * Copyright 2018-2021 Tomasz Linkowski.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 plugins {
   application
 }

--- a/subprojects/samples/lib/pl.tlinkowski.unij.sample.lib.usage.jdk11/src/main/java/module-info.java
+++ b/subprojects/samples/lib/pl.tlinkowski.unij.sample.lib.usage.jdk11/src/main/java/module-info.java
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2018-2019 Tomasz Linkowski.
+ * Copyright 2018-2021 Tomasz Linkowski.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 /**
  * @author Tomasz Linkowski
  */

--- a/subprojects/samples/lib/pl.tlinkowski.unij.sample.lib.usage.jdk11/src/main/java/pl/tlinkowski/unij/sample/lib/usage/jdk11/SampleLogicMain.java
+++ b/subprojects/samples/lib/pl.tlinkowski.unij.sample.lib.usage.jdk11/src/main/java/pl/tlinkowski/unij/sample/lib/usage/jdk11/SampleLogicMain.java
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2018-2019 Tomasz Linkowski.
+ * Copyright 2018-2021 Tomasz Linkowski.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/subprojects/samples/lib/pl.tlinkowski.unij.sample.lib.usage.jdk11/src/main/java/pl/tlinkowski/unij/sample/lib/usage/jdk11/package-info.java
+++ b/subprojects/samples/lib/pl.tlinkowski.unij.sample.lib.usage.jdk11/src/main/java/pl/tlinkowski/unij/sample/lib/usage/jdk11/package-info.java
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2018-2019 Tomasz Linkowski.
+ * Copyright 2018-2021 Tomasz Linkowski.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 /**
  * @author Tomasz Linkowski
  */

--- a/subprojects/samples/lib/pl.tlinkowski.unij.sample.lib.usage.jdk11/src/test/groovy/pl/tlinkowski/unij/sample/lib/usage/jdk11/SampleLogicSpec.groovy
+++ b/subprojects/samples/lib/pl.tlinkowski.unij.sample.lib.usage.jdk11/src/test/groovy/pl/tlinkowski/unij/sample/lib/usage/jdk11/SampleLogicSpec.groovy
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2018-2019 Tomasz Linkowski.
+ * Copyright 2018-2021 Tomasz Linkowski.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package pl.tlinkowski.unij.sample.lib.usage.jdk11
 
 import spock.lang.Specification

--- a/subprojects/samples/lib/pl.tlinkowski.unij.sample.lib.usage.jdk8/pl.tlinkowski.unij.sample.lib.usage.jdk8.gradle.kts
+++ b/subprojects/samples/lib/pl.tlinkowski.unij.sample.lib.usage.jdk8/pl.tlinkowski.unij.sample.lib.usage.jdk8.gradle.kts
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2018-2019 Tomasz Linkowski.
+ * Copyright 2018-2021 Tomasz Linkowski.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 plugins {
   application
 }

--- a/subprojects/samples/lib/pl.tlinkowski.unij.sample.lib.usage.jdk8/src/main/java/module-info.java
+++ b/subprojects/samples/lib/pl.tlinkowski.unij.sample.lib.usage.jdk8/src/main/java/module-info.java
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2018-2019 Tomasz Linkowski.
+ * Copyright 2018-2021 Tomasz Linkowski.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 /**
  * @author Tomasz Linkowski
  */

--- a/subprojects/samples/lib/pl.tlinkowski.unij.sample.lib.usage.jdk8/src/main/java/pl/tlinkowski/unij/sample/lib/usage/jdk8/SampleLogicMain.java
+++ b/subprojects/samples/lib/pl.tlinkowski.unij.sample.lib.usage.jdk8/src/main/java/pl/tlinkowski/unij/sample/lib/usage/jdk8/SampleLogicMain.java
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2018-2019 Tomasz Linkowski.
+ * Copyright 2018-2021 Tomasz Linkowski.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/subprojects/samples/lib/pl.tlinkowski.unij.sample.lib.usage.jdk8/src/main/java/pl/tlinkowski/unij/sample/lib/usage/jdk8/package-info.java
+++ b/subprojects/samples/lib/pl.tlinkowski.unij.sample.lib.usage.jdk8/src/main/java/pl/tlinkowski/unij/sample/lib/usage/jdk8/package-info.java
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2018-2019 Tomasz Linkowski.
+ * Copyright 2018-2021 Tomasz Linkowski.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 /**
  * @author Tomasz Linkowski
  */

--- a/subprojects/samples/lib/pl.tlinkowski.unij.sample.lib.usage.jdk8/src/test/groovy/pl/tlinkowski/unij/sample/lib/usage/jdk8/SampleLogicSpec.groovy
+++ b/subprojects/samples/lib/pl.tlinkowski.unij.sample.lib.usage.jdk8/src/test/groovy/pl/tlinkowski/unij/sample/lib/usage/jdk8/SampleLogicSpec.groovy
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2018-2019 Tomasz Linkowski.
+ * Copyright 2018-2021 Tomasz Linkowski.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package pl.tlinkowski.unij.sample.lib.usage.jdk8
 
 import spock.lang.Specification

--- a/subprojects/samples/lib/pl.tlinkowski.unij.sample.lib/pl.tlinkowski.unij.sample.lib.gradle.kts
+++ b/subprojects/samples/lib/pl.tlinkowski.unij.sample.lib/pl.tlinkowski.unij.sample.lib.gradle.kts
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2018-2019 Tomasz Linkowski.
+ * Copyright 2018-2021 Tomasz Linkowski.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 modularity.mixedJavaRelease(8)
 
 dependencies {

--- a/subprojects/samples/lib/pl.tlinkowski.unij.sample.lib/src/main/java/module-info.java
+++ b/subprojects/samples/lib/pl.tlinkowski.unij.sample.lib/src/main/java/module-info.java
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2018-2019 Tomasz Linkowski.
+ * Copyright 2018-2021 Tomasz Linkowski.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 /**
  * @author Tomasz Linkowski
  */

--- a/subprojects/samples/lib/pl.tlinkowski.unij.sample.lib/src/main/java/pl/tlinkowski/unij/sample/lib/SampleLogic.java
+++ b/subprojects/samples/lib/pl.tlinkowski.unij.sample.lib/src/main/java/pl/tlinkowski/unij/sample/lib/SampleLogic.java
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2018-2019 Tomasz Linkowski.
+ * Copyright 2018-2021 Tomasz Linkowski.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/subprojects/samples/lib/pl.tlinkowski.unij.sample.lib/src/main/java/pl/tlinkowski/unij/sample/lib/package-info.java
+++ b/subprojects/samples/lib/pl.tlinkowski.unij.sample.lib/src/main/java/pl/tlinkowski/unij/sample/lib/package-info.java
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2018-2019 Tomasz Linkowski.
+ * Copyright 2018-2021 Tomasz Linkowski.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 /**
  * @author Tomasz Linkowski
  */

--- a/subprojects/samples/lib/pl.tlinkowski.unij.sample.lib/src/test/groovy/pl/tlinkowski/unij/sample/lib/SampleLogicSpec.groovy
+++ b/subprojects/samples/lib/pl.tlinkowski.unij.sample.lib/src/test/groovy/pl/tlinkowski/unij/sample/lib/SampleLogicSpec.groovy
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2018-2019 Tomasz Linkowski.
+ * Copyright 2018-2021 Tomasz Linkowski.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package pl.tlinkowski.unij.sample.lib
 
 import spock.lang.Specification


### PR DESCRIPTION
this should resolve the issues in #55 

when doing an unpacking of the jar in maven central there are 2 class files with the same name. after some investigation the first file is compiled for jdk8 and the second for jdk9. the second one is what looks to get loaded by java on the classpath causing the error

```
java.lang.UnsupportedClassVersionError: pl/tlinkowski/unij/service/collect/jdk8/Jdk8UnmodifiableListFactory has been compiled by a more recent version of the Java Runtime (class file version 53.0), this version of the Java Runtime only recognizes class file versions up to 52.0
```

when ran on jdk8. this change excludes any duplicate files added to the jar package.

post-changes i see the following

```
$ jar xfv /Users/kmcgovern/.m2//repository/pl/tlinkowski/unij/pl.tlinkowski.unij.service.collect.jdk8/0.1.2-SNAPSHOT/pl.tlinkowski.unij.service.collect.jdk8-0.1.2-SNAPSHOT.jar
  created: META-INF/
 inflated: META-INF/MANIFEST.MF
 inflated: META-INF/LICENSE
  created: META-INF/maven/
  created: META-INF/maven/pl.tlinkowski.unij/
  created: META-INF/maven/pl.tlinkowski.unij/pl.tlinkowski.unij.service.collect.jdk8/
 inflated: META-INF/maven/pl.tlinkowski.unij/pl.tlinkowski.unij.service.collect.jdk8/pom.xml
 inflated: META-INF/maven/pl.tlinkowski.unij/pl.tlinkowski.unij.service.collect.jdk8/pom.properties
  created: pl/
  created: pl/tlinkowski/
  created: pl/tlinkowski/unij/
  created: pl/tlinkowski/unij/service/
  created: pl/tlinkowski/unij/service/collect/
  created: pl/tlinkowski/unij/service/collect/jdk8/
 inflated: pl/tlinkowski/unij/service/collect/jdk8/Jdk8UnmodifiableSetFactory.class
 inflated: pl/tlinkowski/unij/service/collect/jdk8/Jdk8UnmodifiableSetFactory$Builder.class
 inflated: pl/tlinkowski/unij/service/collect/jdk8/Jdk8UnmodifiableMapFactory.class
 inflated: pl/tlinkowski/unij/service/collect/jdk8/package-info.class
 inflated: pl/tlinkowski/unij/service/collect/jdk8/Jdk8UnmodifiableListFactory.class
 inflated: pl/tlinkowski/unij/service/collect/jdk8/Jdk8UnmodifiableMapFactory$Builder.class
  created: META-INF/services/
 inflated: META-INF/services/pl.tlinkowski.unij.service.api.collect.UnmodifiableSetFactory
 inflated: META-INF/services/pl.tlinkowski.unij.service.api.collect.UnmodifiableListFactory
 inflated: META-INF/services/pl.tlinkowski.unij.service.api.collect.UnmodifiableMapFactory
 inflated: module-info.class
$ find . -name '*.class' | xargs -t -n1 javap -verbose | grep -i major
javap -verbose ./pl/tlinkowski/unij/service/collect/jdk8/Jdk8UnmodifiableSetFactory.class
  major version: 52
javap -verbose ./pl/tlinkowski/unij/service/collect/jdk8/Jdk8UnmodifiableSetFactory$Builder.class
  major version: 52
javap -verbose ./pl/tlinkowski/unij/service/collect/jdk8/Jdk8UnmodifiableMapFactory.class
  major version: 52
javap -verbose ./pl/tlinkowski/unij/service/collect/jdk8/package-info.class
  major version: 52
javap -verbose ./pl/tlinkowski/unij/service/collect/jdk8/Jdk8UnmodifiableListFactory.class
  major version: 52
javap -verbose ./pl/tlinkowski/unij/service/collect/jdk8/Jdk8UnmodifiableMapFactory$Builder.class
  major version: 52
javap -verbose ./module-info.class
  major version: 53
  ```